### PR TITLE
Path parsing fixed

### DIFF
--- a/backend/strutils.c
+++ b/backend/strutils.c
@@ -64,7 +64,7 @@ int parse_path(char* request, int request_size, char** path, const int buffer_si
     for ( int i = 0; i < request_size; i++ )
     {
         // first "/" indicates the beginning of the path
-        if ( request[i] == '/' )
+        if ( request[i] == '/' && !started )
         {
             started = 1;
             continue;


### PR DESCRIPTION
Before fix fonts could not be loaded, because path was parsed as "frontend/fontsFONT_NAME" (without 2nd slash).
Misbehavior occurred due to the lack of extra condition(see code).