### PR TITLE
Segfault when spamming fixed

### DIFF
--- a/backend/include/strutils.h
+++ b/backend/include/strutils.h
@@ -5,6 +5,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <errno.h>
 
 // Checks if string ends with suffix
 int ends_with(const char *str, const char *suffix);

--- a/backend/strutils.c
+++ b/backend/strutils.c
@@ -32,6 +32,14 @@ int read_file(char* path, char** data)
     // Open file
     FILE* f = fopen(selected, "rb");
 
+    // If cannot open, retry every second
+    while ( f == NULL )
+    {
+        printf("\n\n [ERROR] File opening error: <%s> %s\n\n", selected, strerror(errno));
+        sleep(1);
+        f = fopen(selected, "rb");
+    }
+
     // Get length of file
     fseek(f, 0, SEEK_END);
     long fsize = ftell(f);


### PR DESCRIPTION
Solves #21 

Turns out that socket file descriptors from every connection were not closing. At some point, system forbid program to create a new ones, so fopen() returned NULL, causing fseek() to throw segfault.

Changes also enable server to handle multiple connections at once forking the parent process.